### PR TITLE
Add modular session result page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Mathex Split Pages
 
 This repository now contains separate HTML files for each page of the application.
-Each page has its related HTML, CSS, and JavaScript bundled in a single file.
+Most pages bundle HTML, CSS, and JavaScript in a single file. The new
+`session-result.html` page demonstrates a more modular approach by loading its
+styles and scripts from separate files.
 
 Available pages:
 - `dashboard.html`
 - `practice.html`
 - `study.html`
 - `review.html`
+- `session-result.html` (with `session-result.css` and `session-result.js`)
 
 Use `index.html` to access links to these pages.

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <li><a href="practice.html">Practice</a></li>
     <li><a href="study.html">Study</a></li>
     <li><a href="review.html">Review</a></li>
+    <li><a href="session-result.html">Session Results</a></li>
   </ul>
 </body>
 </html>

--- a/session-result.css
+++ b/session-result.css
@@ -1,0 +1,13 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+    background-color: #f4f4f4;
+}
+
+#results-container {
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}

--- a/session-result.html
+++ b/session-result.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Session Results</title>
+    <link rel="stylesheet" href="session-result.css">
+</head>
+<body>
+    <h1>Session Results</h1>
+    <div id="results-container">
+        <!-- Results will be inserted here by session-result.js -->
+    </div>
+    <script src="session-result.js"></script>
+</body>
+</html>

--- a/session-result.js
+++ b/session-result.js
@@ -1,0 +1,4 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const container = document.getElementById('results-container');
+    container.textContent = 'Results will be displayed here.';
+});


### PR DESCRIPTION
## Summary
- create `session-result.html` page
- extract CSS to `session-result.css`
- add basic script `session-result.js`
- link new page from `index.html`
- update README with new page details

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e965fb030832bb7c35b2cb1624d15