### PR TITLE
Add grid line labels to performance graph

### DIFF
--- a/app.html
+++ b/app.html
@@ -57,10 +57,11 @@
               <div class="dashboard-grid">
                   <!-- Performance Trends Chart -->
                   <div class="graph-subcard" id="performanceTrendContainer">
-                      <h4 class="subheading" style="text-align:center; margin-top:0; border:none;">Performance Trends</h4>
-                      <div id="performanceTrendChart" class="time-graph" role="figure" aria-labelledby="performanceTrendHeading">
+                      <h4 class="subheading" id="performanceTrendHeading" style="text-align:center; margin-top:0; border:none;">Performance Trends</h4>
+                     <div id="performanceTrendChart" class="line-graph" role="figure" aria-labelledby="performanceTrendHeading">
                           <div style="color: var(--text-secondary); font-style: italic; padding: 20px;">Performance history will be charted here.</div>
                       </div>
+                      <div id="performanceTrendLegend" class="line-chart-legend"></div>
                   </div>
                   <!-- Mastery Evolution Chart -->
                   <div class="graph-subcard" id="masteryTrendContainer">

--- a/app.html
+++ b/app.html
@@ -689,7 +689,7 @@
   <div id="graphTooltip"></div>
 
   <!-- Back to Top Button (Global) -->
-  <button id="back-to-top-btn" title="Back to Top">↑</button> <!-- Simple up arrow -->
+  <button id="back-to-top-btn" title="Back to Top" aria-label="Back to Top">↑</button>
 
   <!-- Link to the external JavaScript file -->
   <script>

--- a/main.js
+++ b/main.js
@@ -88,6 +88,7 @@ const totalTimeNumberEl = document.getElementById('totalTimeNumber');
 const graphTooltipEl = document.getElementById('graphTooltip');
 const summaryPieChartContainer = document.getElementById('summaryPieChartContainer');
 const summaryPieChartLegend = document.getElementById('summaryPieChartLegend');
+const performanceTrendLegend = document.getElementById('performanceTrendLegend');
 const hamburgerBtn = document.getElementById('hamburgerBtn');
 const mainNav = document.getElementById('main-nav');
 const navLinks = mainNav?.querySelectorAll('.nav-list a[data-area]') || []; // Get area links
@@ -344,6 +345,12 @@ function formatTime(ms, showDecimals = true) {
              return `${seconds}s`;
         }
     }
+}
+
+function formatHalfSeconds(ms) {
+    if (ms === null || typeof ms !== 'number' || isNaN(ms) || ms < 0) return '0s';
+    const sec = (ms / 1000).toFixed(1);
+    return sec.replace(/\.0$/, '') + 's';
 }
 
  function formatBigNumber(num) {
@@ -2502,53 +2509,167 @@ function renderPerformanceTrendChart(sessionHistory) {
         return validTimes.length > 0 ? validTimes.reduce((a, b) => a + b, 0) / validTimes.length : 0;
     });
 
-    const maxAvgTime = Math.max(...avgTimes, 1);
+    const maxAvgTime = Math.max(...avgTimes, 500);
+    const timeUpper = Math.ceil(maxAvgTime / 500) * 500;
+    const graphWidth = container.clientWidth || history.length * 40;
     const graphHeight = container.clientHeight || 200;
-    const maxBarHeight = graphHeight * 0.9;
-    const minBarHeight = 2;
-    
-    // Simple bar chart visualization
-    history.forEach((session, i) => {
-        const accuracyHeight = Math.max(minBarHeight, (accuracies[i] / 100) * maxBarHeight);
-        const timeHeight = Math.max(minBarHeight, (avgTimes[i] / maxAvgTime) * maxBarHeight);
+    const margin = 40; // extra space for grid labels
+    const width = graphWidth - margin * 2;
+    const height = graphHeight - margin * 2;
+    const step = width / (history.length - 1);
 
-        const barGroup = document.createElement('div');
-        barGroup.classList.add('bar');
-        barGroup.style.flexDirection = 'row';
-        barGroup.style.gap = '2px';
-        barGroup.setAttribute('tabindex', '0');
-        barGroup.setAttribute('aria-label', `Session ${i+1}: Accuracy ${accuracies[i].toFixed(1)}%, Avg. Time ${formatTime(avgTimes[i])}`);
+    const svgNS = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('viewBox', `0 0 ${graphWidth} ${graphHeight}`);
+    svg.setAttribute('width', '100%');
+    svg.setAttribute('height', '100%');
 
-        // Accuracy bar
-        const accBar = document.createElement('div');
-        accBar.classList.add('bar-inner', 'correct');
-        accBar.style.height = `${accuracyHeight}px`;
-        accBar.style.width = '8px';
-        accBar.title = `Accuracy: ${accuracies[i].toFixed(1)}%`;
-        
-        // Time bar
-        const timeBar = document.createElement('div');
-        timeBar.classList.add('bar-inner');
-        timeBar.style.backgroundColor = 'var(--mastery-color)';
-        timeBar.style.height = `${timeHeight}px`;
-        timeBar.style.width = '8px';
-        timeBar.title = `Avg. Time: ${formatTime(avgTimes[i])}`;
-        
-        const label = document.createElement('div');
-        label.classList.add('bar-label');
-        label.textContent = i + 1;
+    const accPoints = accuracies.map((a, i) => ({
+        x: margin + i * step,
+        y: margin + height - (a / 100) * height,
+    }));
+    const timePoints = avgTimes.map((t, i) => ({
+        x: margin + i * step,
+        y: margin + height - (t / timeUpper) * height,
+    }));
 
-        const barContainer = document.createElement('div');
-        barContainer.style.display = 'flex';
-        barContainer.style.flexDirection = 'column';
-        barContainer.style.alignItems = 'center';
-        
-        barGroup.appendChild(accBar);
-        barGroup.appendChild(timeBar);
-        barContainer.appendChild(barGroup);
-        barContainer.appendChild(label);
-        container.appendChild(barContainer);
+    // Grid lines
+    const gridLines = Math.max(1, Math.round(timeUpper / 500));
+    for (let i = 0; i <= gridLines; i++) {
+        const ratio = i / gridLines;
+        const y = margin + ratio * height;
+
+        const line = document.createElementNS(svgNS, 'line');
+        line.setAttribute('x1', margin);
+        line.setAttribute('x2', margin + width);
+        line.setAttribute('y1', y);
+        line.setAttribute('y2', y);
+        line.setAttribute('stroke', 'var(--text-secondary)');
+        line.setAttribute('stroke-width', 1);
+        line.setAttribute('opacity', 0.2);
+        svg.appendChild(line);
+
+        const timeLabel = document.createElementNS(svgNS, 'text');
+        timeLabel.setAttribute('class', 'grid-label');
+        timeLabel.setAttribute('x', margin - 6);
+        timeLabel.setAttribute('y', y + 4);
+        timeLabel.setAttribute('text-anchor', 'end');
+        timeLabel.textContent = formatHalfSeconds(timeUpper * (1 - ratio));
+        svg.appendChild(timeLabel);
+
+        const accLabel = document.createElementNS(svgNS, 'text');
+        accLabel.setAttribute('class', 'grid-label');
+        accLabel.setAttribute('x', margin + width + 6);
+        accLabel.setAttribute('y', y + 4);
+        accLabel.setAttribute('text-anchor', 'start');
+        accLabel.textContent = `${Math.round((1 - ratio) * 100)}%`;
+        svg.appendChild(accLabel);
+    }
+
+    // Axes
+    const xAxis = document.createElementNS(svgNS, 'line');
+    xAxis.setAttribute('x1', margin);
+    xAxis.setAttribute('x2', margin + width);
+    xAxis.setAttribute('y1', margin + height);
+    xAxis.setAttribute('y2', margin + height);
+    xAxis.setAttribute('stroke', 'var(--text-secondary)');
+    xAxis.setAttribute('stroke-width', 1);
+    svg.appendChild(xAxis);
+
+    const yAxis = document.createElementNS(svgNS, 'line');
+    yAxis.setAttribute('x1', margin);
+    yAxis.setAttribute('x2', margin);
+    yAxis.setAttribute('y1', margin);
+    yAxis.setAttribute('y2', margin + height);
+    yAxis.setAttribute('stroke', 'var(--text-secondary)');
+    yAxis.setAttribute('stroke-width', 1);
+    svg.appendChild(yAxis);
+
+    // Axis labels
+    const xLabel = document.createElementNS(svgNS, 'text');
+    xLabel.setAttribute('x', graphWidth / 2);
+    xLabel.setAttribute('y', graphHeight - 5);
+    xLabel.setAttribute('text-anchor', 'middle');
+    xLabel.setAttribute('fill', 'var(--text-secondary)');
+    xLabel.setAttribute('font-size', '12');
+    xLabel.textContent = 'Session';
+    svg.appendChild(xLabel);
+
+    const yLabel = document.createElementNS(svgNS, 'text');
+    yLabel.setAttribute('x', 0 - (graphHeight / 2));
+    yLabel.setAttribute('y', 4); // push label further from the y-axis
+    yLabel.setAttribute('transform', `rotate(-90)`);
+    yLabel.setAttribute('text-anchor', 'middle');
+    yLabel.setAttribute('fill', 'var(--text-secondary)');
+    yLabel.setAttribute('font-size', '12');
+    yLabel.textContent = 'Avg Time / Accuracy';
+    svg.appendChild(yLabel);
+
+    const accPath = document.createElementNS(svgNS, 'path');
+    accPath.setAttribute('d', getSmoothPath(accPoints));
+    accPath.setAttribute('fill', 'none');
+    accPath.setAttribute('stroke', 'var(--pill-correct-bg)');
+    accPath.setAttribute('stroke-width', 2);
+
+    const timePath = document.createElementNS(svgNS, 'path');
+    timePath.setAttribute('d', getSmoothPath(timePoints));
+    timePath.setAttribute('fill', 'none');
+    timePath.setAttribute('stroke', 'var(--mastery-color)');
+    timePath.setAttribute('stroke-width', 2);
+
+    svg.appendChild(accPath);
+    svg.appendChild(timePath);
+
+    accPoints.forEach((p, i) => {
+        const dot = document.createElementNS(svgNS, 'circle');
+        dot.setAttribute('cx', p.x);
+        dot.setAttribute('cy', p.y);
+        dot.setAttribute('r', 3);
+        dot.setAttribute('fill', 'var(--pill-correct-bg)');
+        dot.setAttribute('stroke', 'var(--card-bg)');
+        dot.setAttribute('stroke-width', 1);
+        dot.setAttribute('aria-label', `Session ${i+1}: Accuracy ${accuracies[i].toFixed(1)}%`);
+        svg.appendChild(dot);
     });
+
+    timePoints.forEach((p, i) => {
+        const dot = document.createElementNS(svgNS, 'circle');
+        dot.setAttribute('cx', p.x);
+        dot.setAttribute('cy', p.y);
+        dot.setAttribute('r', 3);
+        dot.setAttribute('fill', 'var(--mastery-color)');
+        dot.setAttribute('stroke', 'var(--card-bg)');
+        dot.setAttribute('stroke-width', 1);
+        dot.setAttribute('aria-label', `Session ${i+1}: Avg. Time ${formatTime(avgTimes[i])}`);
+        svg.appendChild(dot);
+    });
+
+    container.appendChild(svg);
+
+    // Legend
+    if (performanceTrendLegend) {
+        performanceTrendLegend.innerHTML = '';
+        const accItem = document.createElement('span');
+        accItem.style.setProperty('--color', getComputedStyle(document.documentElement).getPropertyValue('--pill-correct-bg').trim());
+        accItem.textContent = 'Accuracy';
+        const timeItem = document.createElement('span');
+        timeItem.style.setProperty('--color', getComputedStyle(document.documentElement).getPropertyValue('--mastery-color').trim());
+        timeItem.textContent = 'Avg Time';
+        performanceTrendLegend.appendChild(accItem);
+        performanceTrendLegend.appendChild(timeItem);
+    }
+}
+
+function getSmoothPath(points) {
+    if (points.length < 2) return '';
+    let d = `M ${points[0].x} ${points[0].y}`;
+    for (let i = 0; i < points.length - 1; i++) {
+        const p0 = points[i];
+        const p1 = points[i + 1];
+        const cp1x = p0.x + (p1.x - p0.x) / 2;
+        d += ` C ${cp1x} ${p0.y}, ${cp1x} ${p1.y}, ${p1.x} ${p1.y}`;
+    }
+    return d;
 }
 
 function getAchievements(profile) {

--- a/style.css
+++ b/style.css
@@ -835,6 +835,51 @@ input[type=number] {
 .bar-inner.skipped { background: var(--pill-skipped-bg); }
 .time-graph .bar .bar-label { margin-top: 8px; font-size: 12px; color: var(--text-secondary); text-align: center; font-weight: 500; pointer-events: none; }
 
+/* Line Graph Container */
+.line-graph {
+  position: relative;
+  width: 100%;
+  min-height: 180px;
+  padding: 10px 0;
+}
+.line-graph svg {
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+/* Grid value labels */
+.line-graph text.grid-label {
+  font-size: 12px; /* larger grid indicator text */
+  fill: var(--text-secondary);
+}
+
+/* Legend for line graph */
+.line-chart-legend {
+  display: flex;
+  justify-content: center;
+  gap: 10px 20px;
+  margin-top: 10px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.line-chart-legend span {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 500;
+}
+.line-chart-legend span::before {
+  content: '';
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  margin-right: 6px;
+  background-color: var(--color);
+  box-shadow: 1px 1px 2px rgba(0,0,0,0.2);
+}
+
 /* Detailed Results Table */
 /* This is the container on DESKTOP for the table */
 .detail-table-subcard {
@@ -1467,10 +1512,12 @@ table.detailed-results .pill { margin-left: 5px; margin-right: 0; }
   font-weight: 600;
   font-size: 0.9rem;
 }
- #dashboard-trends .time-graph { /* Reusing time-graph for trend charts */
+ #dashboard-trends .time-graph,
+ #dashboard-trends .line-graph { /* Reusing time-graph for trend charts */
     flex-grow: 1;
     width: 100%;
     padding: 10px 0;
+    aspect-ratio: 1 / 1;
  }
 
 /* ============ REVIEW HISTORY STYLES ============ */

--- a/style.css
+++ b/style.css
@@ -1626,7 +1626,7 @@ table.detailed-results .pill { margin-left: 5px; margin-right: 0; }
 #back-to-top-btn {
     position: fixed;
     bottom: 20px;
-    right: 20px;
+    left: 20px;
     width: 50px;
     height: 50px;
     background-color: var(--card-bg);
@@ -2060,7 +2060,7 @@ table.detailed-results .pill { margin-left: 5px; margin-right: 0; }
   #study-area .control-item { text-align: center; }
   #study-area .control-item label { margin-right: 0; margin-bottom: 5px; display: block;}
   #study-area .neumorphic-input, #study-area .neumorphic-button { width: 100%; text-align: center; }
-  #back-to-top-btn { width: 45px; height: 45px; font-size: 1.3rem; line-height: 45px; bottom: 15px; right: 15px;}
+  #back-to-top-btn { width: 45px; height: 45px; font-size: 1.3rem; line-height: 45px; bottom: 15px; left: 15px; right: auto;}
 
   /* === Mobile Dashboard Adjustments === */
   .dashboard-grid { grid-template-columns: 1fr; /* Stack tables vertically */ }
@@ -2121,7 +2121,7 @@ table.detailed-results .pill { margin-left: 5px; margin-right: 0; }
     #study-area .table-block, #study-area .value-item { font-size: 0.95rem; }
     #study-area .table-block h3 { font-size: 1.1em; }
     #study-area .value-item sup { font-size: 0.7em; }
-    #back-to-top-btn { width: 40px; height: 40px; font-size: 1.2rem; line-height: 40px; bottom: 10px; right: 10px;}
+    #back-to-top-btn { width: 40px; height: 40px; font-size: 1.2rem; line-height: 40px; bottom: 10px; left: 10px; right: auto;}
 
     /* === Review Area Mobile (Small) (NEW) === */
     .session-list-stats { gap: 8px 12px; }


### PR DESCRIPTION
## Summary
- show grid line values for accuracy and average time
- style grid value labels for the line graph
- fix rounding of avg time grid labels by showing decimals
- format time labels in half-second increments
- keep dashboard graphs square
- offset y-axis label from the axis
- increase font size for grid indicators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ee61bb92c832bb3c822ae1d6aa1f0